### PR TITLE
when path is a dir, os.unlink(path) will throw exception

### DIFF
--- a/who_depends_this_lib
+++ b/who_depends_this_lib
@@ -48,7 +48,10 @@ def handle_rmtree_error(tmpdir, func, path, excinfo):
   if isinstance(excinfo[1], PermissionError) and \
      os.path.commonpath((path, tmpdir)) == tmpdir:
     os.chmod(os.path.dirname(path), 0o700)
-    shutil.rmtree(path, onerror=partial(handle_rmtree_error, path))
+    if os.path.isdir(path):
+      shutil.rmtree(path, onerror=partial(handle_rmtree_error, path))
+    else:
+      os.unlink(path)
 
 @contextlib.contextmanager
 def extract_package(pkg):

--- a/who_depends_this_lib
+++ b/who_depends_this_lib
@@ -48,7 +48,7 @@ def handle_rmtree_error(tmpdir, func, path, excinfo):
   if isinstance(excinfo[1], PermissionError) and \
      os.path.commonpath((path, tmpdir)) == tmpdir:
     os.chmod(os.path.dirname(path), 0o700)
-    os.unlink(path)
+    shutil.rmtree(path, onerror=partial(handle_rmtree_error, path))
 
 @contextlib.contextmanager
 def extract_package(pkg):


### PR DESCRIPTION
This try to fix this case by calling shutil.rmtree recursively.

To reproduce the bug, try on a file db with this package: http://repo.archlinuxcn.org/x86_64/packettracer-7.2-1-x86_64.pkg.tar.xz
The error report looks like:
```
[I 01-16 15:17:10.801 who_depends_this_lib:55] extracting packettracer-7.2-1-x86_64.pkg.tar.xz...
[I 01-16 15:17:33.863 who_depends_this_lib:65] checking...
objdump: /tmp/depcheck-4lzkfpbj/usr/share/packettracer/extensions/NetacadExamPlayer/ptplayer/java/bin/jcontrol: file format not recognized
objdump: /tmp/depcheck-4lzkfpbj/usr/share/packettracer/bin/ZIP_LICENSE: file format not recognized
objdump: /tmp/depcheck-4lzkfpbj/usr/share/packettracer/bin/PT.conf: file format not recognized
Traceback (most recent call last):
  File "/usr/lib/python3.7/shutil.py", line 431, in _rmtree_safe_fd
    os.rmdir(entry.name, dir_fd=topfd)
PermissionError: [Errno 13] Permission denied: 'TFTP'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/farseerfc/github/misc_scripts/who_depends_this_lib", line 128, in <module>
    main(args.pkgdb, re.compile(args.libname))
  File "/home/farseerfc/github/misc_scripts/who_depends_this_lib", line 107, in main
    r, lib = check_package(os.path.join(dir, filename), lib_re)
  File "/home/farseerfc/github/misc_scripts/who_depends_this_lib", line 70, in check_package
    return r, lib
  File "/usr/lib/python3.7/contextlib.py", line 119, in __exit__
    next(self.gen)
  File "/home/farseerfc/github/misc_scripts/who_depends_this_lib", line 61, in extract_package
    shutil.rmtree(d, onerror=partial(handle_rmtree_error, d))
  File "/usr/lib/python3.7/shutil.py", line 491, in rmtree
    _rmtree_safe_fd(fd, path, onerror)
  File "/usr/lib/python3.7/shutil.py", line 429, in _rmtree_safe_fd
    _rmtree_safe_fd(dirfd, fullname, onerror)
  File "/usr/lib/python3.7/shutil.py", line 429, in _rmtree_safe_fd
    _rmtree_safe_fd(dirfd, fullname, onerror)
  File "/usr/lib/python3.7/shutil.py", line 429, in _rmtree_safe_fd
    _rmtree_safe_fd(dirfd, fullname, onerror)
  [Previous line repeated 2 more times]
  File "/usr/lib/python3.7/shutil.py", line 433, in _rmtree_safe_fd
    onerror(os.rmdir, fullname, sys.exc_info())
  File "/home/farseerfc/github/misc_scripts/who_depends_this_lib", line 51, in handle_rmtree_error
    os.unlink(path)
IsADirectoryError: [Errno 21] Is a directory: '/tmp/depcheck-4lzkfpbj/usr/share/packettracer/saves/TCP_IP/TFTP'
```