### PR TITLE
who_depends_this_lib: support *.pkg.tar.zst

### DIFF
--- a/who_depends_this_lib
+++ b/who_depends_this_lib
@@ -11,6 +11,7 @@ import re
 import shutil
 from functools import partial
 
+import zstandard
 from cmdutils import so_depends
 
 logger = logging.getLogger(__name__)
@@ -64,6 +65,16 @@ def extract_package(pkg):
   finally:
     shutil.rmtree(d, onerror=partial(handle_rmtree_error, d))
 
+@contextlib.contextmanager
+def tarfile_open_zstd_compat(name):
+  if name.endswith('.zst'):
+    dctx = zstandard.ZstdDecompressor()
+    with open(name, 'rb') as f, dctx.stream_reader(f) as reader, tarfile.open(mode='r|', fileobj=reader) as tar:
+      yield tar
+  else:
+    with tarfile.open(name) as tar:
+      yield tar
+
 def check_package(pkg, lib_re, dep_pkgname):
   # If a package links to a library that matches `lib_re` but does not have
   # `dep_pkgname` installed during the build, that package is already broken
@@ -71,7 +82,7 @@ def check_package(pkg, lib_re, dep_pkgname):
   # protobuf installed during the build.
   has_dep = False
   buildinfo_found = False
-  with tarfile.open(pkg) as tar:
+  with tarfile_open_zstd_compat(pkg) as tar:
     threshold = 10
     for tarinfo in itertools.islice(tar, threshold):
       if tarinfo.name == '.BUILDINFO':


### PR DESCRIPTION
Fix the issue mentioned in https://github.com/archlinuxcn/repo/issues/1378#issuecomment-557888316

This patch requires the python-zstandard [1] package.

[1] https://build.archlinuxcn.org/packages/#/python-zstandard