### PR TITLE
Automatically remove relevant repo_depends entries for official packages

### DIFF
--- a/issuebot
+++ b/issuebot
@@ -112,9 +112,9 @@ Automatically removed.''')
 Already removed.''')
       issue.close()
 
-def remove_repo_depends(name: str, packages: List[str]) -> bool:
+def remove_repo_depends(pkgdir: pathlib.Path, packages: List[str]) -> bool:
   # use ruamel.yaml for yaml manipulation with preserving indents and comments
-  lilac_yaml_path = os.path.join(REPO, name, 'lilac.yaml')
+  lilac_yaml_path = pkgdir / 'lilac.yaml'
 
   with open(lilac_yaml_path) as f:
     lilac_yaml, indent, block_seq_indent = load_yaml_guess_indent(f.read())
@@ -140,7 +140,7 @@ def remove_repo_depends(name: str, packages: List[str]) -> bool:
     with open(lilac_yaml_path, 'w') as f:
       round_trip_dump(lilac_yaml, stream=f, indent=indent,
                       block_seq_indent=block_seq_indent)
-    subprocess.check_call(['git', 'add', name], cwd=REPO)
+    subprocess.check_call(['git', 'add', os.path.basename(pkgdir)], cwd=REPO)
     return True
   else:
     return False
@@ -171,8 +171,8 @@ lilac can't parse out the relevant package names, please handle manually.''')
     with file_lock(LILAC_LOCK):
       subprocess.check_output(['git', 'pull'], cwd=REPO)
 
-      for name in iter_pkgdir(pathlib.Path(REPO)):
-        if remove_repo_depends(name, packages):
+      for pkgdir in iter_pkgdir(pathlib.Path(REPO)):
+        if remove_repo_depends(pkgdir, packages):
           changed = True
 
       for name in packages:

--- a/issuebot
+++ b/issuebot
@@ -6,6 +6,7 @@ import os
 import subprocess
 import shutil
 from typing import List
+
 from ruamel.yaml import round_trip_dump
 from ruamel.yaml.util import load_yaml_guess_indent
 

--- a/issuebot
+++ b/issuebot
@@ -5,6 +5,9 @@ import sys
 import os
 import subprocess
 import shutil
+from typing import List
+from ruamel.yaml import round_trip_dump
+from ruamel.yaml.util import load_yaml_guess_indent
 
 from github import GitHub
 from myutils import file_lock
@@ -105,6 +108,36 @@ Automatically removed.''')
 Already removed.''')
       issue.close()
 
+def remove_repo_depends(name: str, packages: List[str]):
+  # use ruamel.yaml for yaml manipulation with preserving indents and comments
+  lilac_yaml_path = os.path.join(REPO, name, 'lilac.yaml')
+
+  with open(lilac_yaml_path) as f:
+    lilac_yaml, indent, block_seq_indent = load_yaml_guess_indent(f.read())
+
+  repo_depends = lilac_yaml.get('repo_depends', [])
+  if not repo_depends:
+    return
+
+  # Find out all repo_depends entries to remove. Not using list comprehension
+  # here so that comments are preserved.
+  target_indexes = []
+  for idx, repo_depend in enumerate(repo_depends):
+    if isinstance(repo_depend, dict):
+      repo_depend = list(repo_depend.keys())[0]
+    if repo_depend in packages:
+      target_indexes.append(idx)
+
+  if target_indexes:
+    for target_idx in sorted(target_indexes, reverse=True):
+      del lilac_yaml['repo_depends'][target_idx]
+    if len(lilac_yaml['repo_depends']) == 0:
+      del lilac_yaml['repo_depends']
+    with open(lilac_yaml_path, 'w') as f:
+      round_trip_dump(lilac_yaml, stream=f, indent=indent,
+                      block_seq_indent=block_seq_indent)
+    subprocess.check_call(['git', 'add', name], cwd=REPO)
+
 def process_in_official(
   gh: GitHub, repo: str, now: datetime.datetime,
 ) -> None:
@@ -130,6 +163,11 @@ lilac can't parse out the relevant package names, please handle manually.''')
 
     with file_lock(LILAC_LOCK):
       subprocess.check_output(['git', 'pull'], cwd=REPO)
+
+      for name in os.listdir(REPO):
+        if not os.path.isdir(os.path.join(REPO, name)):
+            continue
+        remove_repo_depends(name, packages)
 
       for name in packages:
         try:

--- a/issuebot
+++ b/issuebot
@@ -108,7 +108,7 @@ Automatically removed.''')
 Already removed.''')
       issue.close()
 
-def remove_repo_depends(name: str, packages: List[str]):
+def remove_repo_depends(name: str, packages: List[str]) -> bool:
   # use ruamel.yaml for yaml manipulation with preserving indents and comments
   lilac_yaml_path = os.path.join(REPO, name, 'lilac.yaml')
 
@@ -117,7 +117,7 @@ def remove_repo_depends(name: str, packages: List[str]):
 
   repo_depends = lilac_yaml.get('repo_depends', [])
   if not repo_depends:
-    return
+    return False
 
   # Find out all repo_depends entries to remove. Not using list comprehension
   # here so that comments are preserved.
@@ -137,6 +137,9 @@ def remove_repo_depends(name: str, packages: List[str]):
       round_trip_dump(lilac_yaml, stream=f, indent=indent,
                       block_seq_indent=block_seq_indent)
     subprocess.check_call(['git', 'add', name], cwd=REPO)
+    return True
+  else:
+    return False
 
 def process_in_official(
   gh: GitHub, repo: str, now: datetime.datetime,
@@ -167,7 +170,8 @@ lilac can't parse out the relevant package names, please handle manually.''')
       for name in os.listdir(REPO):
         if not os.path.isdir(os.path.join(REPO, name)):
             continue
-        remove_repo_depends(name, packages)
+        if remove_repo_depends(name, packages):
+          changed = True
 
       for name in packages:
         try:

--- a/issuebot
+++ b/issuebot
@@ -3,6 +3,7 @@
 import datetime
 import sys
 import os
+import pathlib
 import subprocess
 import shutil
 from typing import List
@@ -12,6 +13,8 @@ from ruamel.yaml.util import load_yaml_guess_indent
 
 from github import GitHub
 from myutils import file_lock
+
+from lilac2.lilacyaml import iter_pkgdir
 
 from webhooks.issue import parse_issue_text
 
@@ -168,9 +171,7 @@ lilac can't parse out the relevant package names, please handle manually.''')
     with file_lock(LILAC_LOCK):
       subprocess.check_output(['git', 'pull'], cwd=REPO)
 
-      for name in os.listdir(REPO):
-        if not os.path.isdir(os.path.join(REPO, name)):
-            continue
+      for name in iter_pkgdir(pathlib.Path(REPO)):
         if remove_repo_depends(name, packages):
           changed = True
 
@@ -188,14 +189,14 @@ lilac can't parse out the relevant package names, please handle manually.''')
         if len(packages) > ORPHANED_PACKAGES_BREAKDOWN:
           affected = "\n".join(f"- {x}" for x in packages)
           msg = f'''Removing {len(packages)} packages \
-because they are already in official repos.
+and corresponding repo_depends entries because they are already in official repos.
 
 Affected packages:
 {affected}
 
 closes #{issue.number}'''
         else:
-          msg = f'{", ".join(packages)}: in official repos, removing. closes #{issue.number}'
+          msg = f'{", ".join(packages)}: in official repos, removing packages and repo_depends entries if any. closes #{issue.number}'
         subprocess.check_output(['git', 'commit', '-m', msg], cwd=REPO)
         git_push()
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,3 +18,6 @@ ignore_missing_imports = True
 
 [mypy-structlog]
 ignore_missing_imports = True
+
+[mypy-ruamel.yaml.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Tested with the following cases

* cub
* mxnet-git (involved with split packages)
* lxqt-build-tools, libqtxdg-git (multiple packages)

A sample commit for the last test case can be found at https://github.com/yan12125/repo/commit/49ab72085b3a0c0c9827cff1889feefdb5d14708

Note that a new dependency python-ruamel-yaml is introduced in this pull request.