### PR TITLE
Accumulate download counts for all split packages

### DIFF
--- a/pkg-cleanup/gen-cleanup-list
+++ b/pkg-cleanup/gen-cleanup-list
@@ -10,6 +10,7 @@ import pickle
 import requests
 
 from lilac2 import lilacyaml
+from lilac2.packages import get_split_packages
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,10 @@ class PkgInfo(NamedTuple):
   dl_count: int
   stats_count: int
   stats_samples: int
-  stats_popularity: float
+
+  @property
+  def stats_popularity(self) -> float:
+    return 100.0 * self.stats_count / self.stats_samples
 
 DL_COUNT_START = int(time.time() - 3 * 30 * 86400)
 STATS_START = time.strftime(
@@ -38,7 +42,7 @@ def get_dl_count(name: str) -> int:
   j = r.json()
   return j['count']
 
-def get_stats_info(name: str) -> Tuple[int, int, float]:
+def get_stats_info(name: str) -> Tuple[int, int]:
   r = s.get(
     f'https://pkgstats.archlinux.de/api/packages/{name}',
     params = {
@@ -47,7 +51,7 @@ def get_stats_info(name: str) -> Tuple[int, int, float]:
     },
   )
   j = r.json()
-  return j['count'], j['samples'], j['popularity']
+  return j['count'], j['samples']
 
 def gather_data() -> None:
   repodir = Path('/ldata/src/archgitrepo/archlinuxcn')
@@ -55,11 +59,20 @@ def gather_data() -> None:
   for pkgdir in lilacyaml.iter_pkgdir(repodir):
     y = lilacyaml.load_lilac_yaml(pkgdir)
     name = pkgdir.name
-    # TODO: map pkgbase to pkgnames
+    # Accumulate counts for split packages
+    packages = get_split_packages(pkgdir)
+    total_pkgstats_cn_count = 0
+    total_pkgstats_count = 0
+    pkgstats_samples = 0
+    for _, pkgname in packages:
+      total_pkgstats_cn_count += get_dl_count(pkgname)
+      cur_pkgstat_count, pkgstats_samples = get_stats_info(pkgname)
+      total_pkgstats_count += cur_pkgstat_count
     info = PkgInfo(
       name,
-      get_dl_count(name),
-      *get_stats_info(name),
+      total_pkgstats_cn_count,
+      total_pkgstats_count,
+      pkgstats_samples,
     )
     logger.info('Queried: %s', info)
     for m in y.get('maintainers', []):
@@ -77,7 +90,7 @@ def gen_comments() -> List[str]:
     msg = [f'@{who}:']
     pkgs.sort(key=lambda x: x.dl_count + x.stats_count)
     for x in pkgs:
-        msg.append(f'* [ ] {x.pkgbase} ({x.dl_count}) ({x.stats_count}; {x.stats_popularity})')
+        msg.append(f'* [ ] {x.pkgbase} ({x.dl_count}) ({x.stats_count}; {x.stats_popularity:0.2f})')
     ret.append('\n'.join(msg))
 
   return ret


### PR DESCRIPTION
An example run:
```
[D 07-14 19:11:06.993 connectionpool:937] Starting new HTTPS connection (1): archlinuxcn-pkgstats.imlonghao.workers.dev:443
[D 07-14 19:11:07.580 connectionpool:433] https://archlinuxcn-pkgstats.imlonghao.workers.dev:443 "GET /?name=firefox-nightly-zh-cn&timegt=1586949066 HTTP/1.1" 200 None
[D 07-14 19:11:07.582 connectionpool:937] Starting new HTTPS connection (1): pkgstats.archlinux.de:443
[D 07-14 19:11:08.760 connectionpool:433] https://pkgstats.archlinux.de:443 "GET /api/packages/firefox-nightly-zh-cn?startMonth=202004&endMonth=202007 HTTP/1.1" 200 None
[D 07-14 19:11:09.023 connectionpool:433] https://archlinuxcn-pkgstats.imlonghao.workers.dev:443 "GET /?name=firefox-nightly-en-us&timegt=1586949066 HTTP/1.1" 200 None
[D 07-14 19:11:09.326 connectionpool:433] https://pkgstats.archlinux.de:443 "GET /api/packages/firefox-nightly-en-us?startMonth=202004&endMonth=202007 HTTP/1.1" 200 None
[D 07-14 19:11:09.542 connectionpool:433] https://archlinuxcn-pkgstats.imlonghao.workers.dev:443 "GET /?name=firefox-nightly-zh-tw&timegt=1586949066 HTTP/1.1" 200 None
[D 07-14 19:11:09.846 connectionpool:433] https://pkgstats.archlinux.de:443 "GET /api/packages/firefox-nightly-zh-tw?startMonth=202004&endMonth=202007 HTTP/1.1" 200 None
[D 07-14 19:11:10.060 connectionpool:433] https://archlinuxcn-pkgstats.imlonghao.workers.dev:443 "GET /?name=firefox-nightly-ja&timegt=1586949066 HTTP/1.1" 200 None
[D 07-14 19:11:10.363 connectionpool:433] https://pkgstats.archlinux.de:443 "GET /api/packages/firefox-nightly-ja?startMonth=202004&endMonth=202007 HTTP/1.1" 200 None
[I 07-14 19:11:10.364 gen-cleanup-list:79] Queried: PkgInfo(pkgbase='firefox-nightly', dl_count=5453, stats_count=180, stats_samples=62912)

* [ ] firefox-nightly (5453) (180; 0.29)
```

Depends on https://github.com/archlinuxcn/lilac/pull/158. For https://github.com/archlinuxcn/repo/issues/1739#issuecomment-657458951.